### PR TITLE
css collapse

### DIFF
--- a/src/plugins/tidgraph/stylesheet.tid
+++ b/src/plugins/tidgraph/stylesheet.tid
@@ -126,6 +126,14 @@ type: text/css
     -webkit-transform: translateX(-50%);
 }
 
+.ihm-tgr-collapse-open:before{
+	content:"+";
+}
+
+.ihm-tgr-collapse-close:before{
+	content:"&middot;";
+}
+
 a.ihm-tgr-collapse:hover {
     text-decoration: none;
     background: #999999;

--- a/src/plugins/tidgraph/stylesheet.tid
+++ b/src/plugins/tidgraph/stylesheet.tid
@@ -103,20 +103,23 @@ type: text/css
     position: absolute;
     cursor: pointer;
     color: white !important;
-    border-radius: 20px;
-    line-height: 14px;
-    width: 12px;
-    height: 15px;
+    border-radius: 11px;
+    width: 11px;
+    height: 11px;
     background: #aeb0b5;
     right: -14px;
-    font: 12px Arial, sans-serif;
+	text-align: center;
+    font-size: 11px;
+	line-height:9px;
+	display: table-cell;
+    vertical-align: middle;
 }
 
 .ihm-tgr-collapse-east {
-    top: 50%;
-    transform: translateY(-50%);
-    -ms-transform: translateY(-50%);
-    -webkit-transform: translateY(-50%);
+    top: 53%;
+    transform: translateY(-53%);
+    -ms-transform: translateY(-53%);
+    -webkit-transform: translateY(-53%);
 }
 
 .ihm-tgr-collapse-south {
@@ -130,8 +133,12 @@ type: text/css
 	content:"+";
 }
 
+.ihm-tgr-collapse-close{
+	line-height:10px;
+}
+
 .ihm-tgr-collapse-close:before{
-	content:"&middot;";
+	content:"-";
 }
 
 a.ihm-tgr-collapse:hover {

--- a/src/plugins/tidgraph/utils.js
+++ b/src/plugins/tidgraph/utils.js
@@ -125,8 +125,7 @@ exports.buildTable = function(rootTid, tidtree) {
      var layoutcls = (node.widget.tidtree.layout=='E') ?
         "ihm-tgr-collapse-east": "ihm-tgr-collapse-south";
      var collapse = dm('a',{
-		"class": "ihm-tgr-collapse " + layoutcls,
-		"innerHTML": "<span class='ihm-tgr-collapse-" + (node.collapse ? "open" : "close") + "'/>"
+		"class": "ihm-tgr-collapse " + layoutcls + " ihm-tgr-collapse-" + (node.collapse ? "open" : "close")
 	 });
 
     // Add a click event handler for the collapse + or -

--- a/src/plugins/tidgraph/utils.js
+++ b/src/plugins/tidgraph/utils.js
@@ -122,15 +122,17 @@ exports.buildTable = function(rootTid, tidtree) {
 
   function makeCollapseLink(node) {
      //Build collapse link
-     var layoutcls = (node.widget.tidtree.layout=='E') ? 
-        "ihm-tgr-collapse-east":"ihm-tgr-collapse-south";
-     var collapse = dm('a',{"class": "ihm-tgr-collapse "+ layoutcls + " tc-tiddlylink",
-                             text: node.collapse ?   '⊕' : '⊖'});
+     var layoutcls = (node.widget.tidtree.layout=='E') ?
+        "ihm-tgr-collapse-east": "ihm-tgr-collapse-south";
+     var collapse = dm('a',{
+		"class": "ihm-tgr-collapse " + layoutcls,
+		"innerHTML": "<span class='ihm-tgr-collapse-" + (node.collapse ? "open" : "close") + "'/>"
+	 });
 
     // Add a click event handler for the collapse + or -
     $tw.utils.addEventListeners(collapse,[
-          {name: "click", 
-           handlerObject: node, 
+          {name: "click",
+           handlerObject: node,
            handlerMethod: "collapseClickEvent"}
           ]);
     return collapse;


### PR DESCRIPTION
Ih @ihm4u,

I fiddled quite a bit around to eventually make the **ihm-tgr-collapse** customizable via css.
For me, it's now properly centered in both FF and Chrome.
I imagine your code-changes are fast paced, so use / merge as you see fit.
